### PR TITLE
Subsystem sessions support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>fob</groupId>
     <artifactId>commons-ssh</artifactId>
-    <version>2.0.5-SNAPSHOT</version>
+    <version>2.0.6-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>commons-ssh-${version}</name>

--- a/src/src/net/sf/commons/ssh/Feature.java
+++ b/src/src/net/sf/commons/ssh/Feature.java
@@ -27,6 +27,10 @@ public enum Feature {
      */
     SESSION_SHELL,
     /**
+     * Subsystem session feature
+     */
+    SESSION_SUBSYSTEM,
+    /**
      * Socket timeout supports
      */
     SOCKET_TIMEOUT,

--- a/src/src/net/sf/commons/ssh/connection/AbstractConnection.java
+++ b/src/src/net/sf/commons/ssh/connection/AbstractConnection.java
@@ -11,11 +11,7 @@ import net.sf.commons.ssh.event.ProducerType;
 import net.sf.commons.ssh.event.events.AuthenticatedEvent;
 import net.sf.commons.ssh.options.IllegalPropertyException;
 import net.sf.commons.ssh.options.Properties;
-import net.sf.commons.ssh.session.ExecSession;
-import net.sf.commons.ssh.session.ExecSessionPropertiesBuilder;
-import net.sf.commons.ssh.session.SFTPSession;
-import net.sf.commons.ssh.session.Session;
-import net.sf.commons.ssh.session.ShellSession;
+import net.sf.commons.ssh.session.*;
 import net.sf.commons.ssh.errors.Error;
 
 /**
@@ -48,6 +44,14 @@ public abstract class AbstractConnection extends AbstractContainer<Session> impl
 	public ShellSession openShellSession() throws IOException
 	{
 		ShellSession session = createShellSession();
+		session.open();
+		return session;
+	}
+
+	@Override
+	public SubsystemSession openSubsystemSession() throws IOException
+	{
+		SubsystemSession session = createSubsystemSession();
 		session.open();
 		return session;
 	}

--- a/src/src/net/sf/commons/ssh/connection/Connection.java
+++ b/src/src/net/sf/commons/ssh/connection/Connection.java
@@ -8,6 +8,7 @@ import net.sf.commons.ssh.common.Container;
 import net.sf.commons.ssh.session.ExecSession;
 import net.sf.commons.ssh.session.SFTPSession;
 import net.sf.commons.ssh.session.ShellSession;
+import net.sf.commons.ssh.session.SubsystemSession;
 
 public interface Connection extends Container
 {
@@ -22,10 +23,12 @@ public interface Connection extends Container
     boolean isAuthenticating();
 
     ShellSession createShellSession();
+    SubsystemSession createSubsystemSession();
     ExecSession createExecSession();
     SFTPSession createSFTPSession();
 
     ShellSession openShellSession() throws IOException;
+    SubsystemSession openSubsystemSession() throws IOException;
     ExecSession openExecSession(String command) throws IOException;
     SFTPSession openSFTPSession() throws IOException;
     

--- a/src/src/net/sf/commons/ssh/directory/Description.java
+++ b/src/src/net/sf/commons/ssh/directory/Description.java
@@ -32,9 +32,6 @@ import static net.sf.commons.ssh.directory.XmlUtil.getFromElement;
  */
 public class Description
 {
-
-
-
     static Description loadDescription(Element element)
     {
         Description description = new Description();

--- a/src/src/net/sf/commons/ssh/impl/ganymed/GanymedConnection.java
+++ b/src/src/net/sf/commons/ssh/impl/ganymed/GanymedConnection.java
@@ -4,6 +4,7 @@
 package net.sf.commons.ssh.impl.ganymed;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.security.PublicKey;
 import java.security.SecureRandom;
 
@@ -22,6 +23,7 @@ import net.sf.commons.ssh.options.Properties;
 import net.sf.commons.ssh.session.ExecSession;
 import net.sf.commons.ssh.session.SFTPSession;
 import net.sf.commons.ssh.session.ShellSession;
+import net.sf.commons.ssh.session.SubsystemSession;
 import net.sf.commons.ssh.verification.VerificationPropertiesBuilder;
 import net.sf.commons.ssh.verification.VerificationRepository;
 import ch.ethz.ssh2.Connection;
@@ -107,6 +109,12 @@ public class GanymedConnection extends AbstractConnection
 		}
 		registerChild(session);
 		return session;
+	}
+
+	@Override
+	public SubsystemSession createSubsystemSession()
+	{
+		throw new UnsupportedOperationException("createSubsystemSession is not supported");
 	}
 
 	/**

--- a/src/src/net/sf/commons/ssh/impl/ganymed/GanymedConnection.java
+++ b/src/src/net/sf/commons/ssh/impl/ganymed/GanymedConnection.java
@@ -114,7 +114,22 @@ public class GanymedConnection extends AbstractConnection
 	@Override
 	public SubsystemSession createSubsystemSession()
 	{
-		throw new UnsupportedOperationException("createSubsystemSession is not supported");
+		SubsystemSession session;
+		try
+		{
+			session = new GanymedSubsystemSession(this, connection);
+		}
+		catch (Exception e)
+		{
+			Error error = new Error("Can't create shell session", this, ErrorLevel.ERROR, e, "createSubsystemSession()", log);
+			error.writeLog();
+			pushError(error);
+			if(e instanceof RuntimeException)
+				throw (RuntimeException) e;
+			throw new RuntimeException(e.getMessage(),e);
+		}
+		registerChild(session);
+		return session;
 	}
 
 	/**

--- a/src/src/net/sf/commons/ssh/impl/ganymed/GanymedConnection.java
+++ b/src/src/net/sf/commons/ssh/impl/ganymed/GanymedConnection.java
@@ -121,7 +121,7 @@ public class GanymedConnection extends AbstractConnection
 		}
 		catch (Exception e)
 		{
-			Error error = new Error("Can't create shell session", this, ErrorLevel.ERROR, e, "createSubsystemSession()", log);
+			Error error = new Error("Can't create subsystem session", this, ErrorLevel.ERROR, e, "createSubsystemSession()", log);
 			error.writeLog();
 			pushError(error);
 			if(e instanceof RuntimeException)

--- a/src/src/net/sf/commons/ssh/impl/ganymed/GanymedConnector.java
+++ b/src/src/net/sf/commons/ssh/impl/ganymed/GanymedConnector.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 @SupportedFeatures(
         {
                 Feature.SSH2, Feature.SYNCHRONOUS, Feature.AUTH_CREDENTIALS, Feature.AUTH_PUBLIC_KEY,
-                Feature.CONNECTION_TIMEOUT, Feature.SESSION_SHELL, Feature.ERROR_STREAM,
+                Feature.CONNECTION_TIMEOUT, Feature.SESSION_SHELL, Feature.SESSION_SUBSYSTEM, Feature.ERROR_STREAM,
                 Feature.CONNECT_WITHOUT_AUTHENTICATE, Feature.HTTP_PROXY
         })
 public class GanymedConnector extends AbstractConnector {

--- a/src/src/net/sf/commons/ssh/impl/ganymed/GanymedShellSession.java
+++ b/src/src/net/sf/commons/ssh/impl/ganymed/GanymedShellSession.java
@@ -25,7 +25,7 @@ import net.sf.commons.ssh.event.events.OpennedEvent;
  */
 public class GanymedShellSession extends AbstractSession implements ShellSession 
 {
-	private Session session;
+	protected Session session;
 	
 	/**
 	 * @param properties

--- a/src/src/net/sf/commons/ssh/impl/ganymed/GanymedSubsystemSession.java
+++ b/src/src/net/sf/commons/ssh/impl/ganymed/GanymedSubsystemSession.java
@@ -28,8 +28,8 @@ public class GanymedSubsystemSession extends GanymedShellSession implements Subs
     protected void openImpl() throws IOException
     {
         SubsystemSessionPropertiesBuilder sspb = SubsystemSessionPropertiesBuilder.getInstance();
+        if (log.isTraceEnabled()) log.trace("openImpl(): open ganymed subsystem '" + sspb.getSubsystemName(this) + "' session");
         sspb.verify(this);
-
         session.requestPTY(sspb.getTerminalType(this),
                 sspb.getTerminalCols(this),
                 sspb.getTerminalRows(this),

--- a/src/src/net/sf/commons/ssh/impl/ganymed/GanymedSubsystemSession.java
+++ b/src/src/net/sf/commons/ssh/impl/ganymed/GanymedSubsystemSession.java
@@ -1,0 +1,44 @@
+package net.sf.commons.ssh.impl.ganymed;
+
+import ch.ethz.ssh2.Connection;
+import net.sf.commons.ssh.common.Status;
+import net.sf.commons.ssh.event.events.OpennedEvent;
+import net.sf.commons.ssh.options.Properties;
+import net.sf.commons.ssh.session.SubsystemSession;
+import net.sf.commons.ssh.session.SubsystemSessionPropertiesBuilder;
+
+import java.io.IOException;
+
+/**
+ * @author veentoo
+ * @date 5/5/2016
+ */
+public class GanymedSubsystemSession extends GanymedShellSession implements SubsystemSession {
+    /**
+     * @param properties
+     * @param connection
+     * @throws IOException
+     */
+    public GanymedSubsystemSession(Properties properties, Connection connection) throws IOException
+    {
+        super(properties, connection);
+    }
+
+    @Override
+    protected void openImpl() throws IOException
+    {
+        SubsystemSessionPropertiesBuilder sspb = SubsystemSessionPropertiesBuilder.getInstance();
+        sspb.verify(this);
+
+        session.requestPTY(sspb.getTerminalType(this),
+                sspb.getTerminalCols(this),
+                sspb.getTerminalRows(this),
+                sspb.getTerminalWidth(this),
+                sspb.getTerminalHeight(this),
+                null);
+        session.startSubSystem(sspb.getSubsystemName(this));
+        session.getStderr(); // for unlock
+        setContainerStatus(Status.OPENNED);
+        fire(new OpennedEvent(this));
+    }
+}

--- a/src/src/net/sf/commons/ssh/impl/ganymed/GanymedSubsystemSession.java
+++ b/src/src/net/sf/commons/ssh/impl/ganymed/GanymedSubsystemSession.java
@@ -1,6 +1,7 @@
 package net.sf.commons.ssh.impl.ganymed;
 
 import ch.ethz.ssh2.Connection;
+import net.sf.commons.ssh.common.LogUtils;
 import net.sf.commons.ssh.common.Status;
 import net.sf.commons.ssh.event.events.OpennedEvent;
 import net.sf.commons.ssh.options.Properties;
@@ -28,7 +29,7 @@ public class GanymedSubsystemSession extends GanymedShellSession implements Subs
     protected void openImpl() throws IOException
     {
         SubsystemSessionPropertiesBuilder sspb = SubsystemSessionPropertiesBuilder.getInstance();
-        if (log.isTraceEnabled()) log.trace("openImpl(): open ganymed subsystem '" + sspb.getSubsystemName(this) + "' session");
+        LogUtils.trace(log, "openImpl(): open ganymed subsystem " + sspb.getSubsystemName(this) + " session");
         sspb.verify(this);
         session.requestPTY(sspb.getTerminalType(this),
                 sspb.getTerminalCols(this),

--- a/src/src/net/sf/commons/ssh/impl/j2ssh/J2SSHConnection.java
+++ b/src/src/net/sf/commons/ssh/impl/j2ssh/J2SSHConnection.java
@@ -37,6 +37,7 @@ import net.sf.commons.ssh.options.Properties;
 import net.sf.commons.ssh.session.ExecSession;
 import net.sf.commons.ssh.session.SFTPSession;
 import net.sf.commons.ssh.session.ShellSession;
+import net.sf.commons.ssh.session.SubsystemSession;
 import net.sf.commons.ssh.verification.VerificationPropertiesBuilder;
 import net.sf.commons.ssh.verification.VerificationRepository;
 
@@ -112,6 +113,12 @@ public class J2SSHConnection extends AbstractConnection
 		ShellSession session = new J2SSHShellSession(this,connection);
 		registerChild(session);
 		return session;
+	}
+
+	@Override
+	public SubsystemSession createSubsystemSession()
+	{
+		throw new UnsupportedOperationException("createSubsystemSession is not supported");
 	}
 
 	/**

--- a/src/src/net/sf/commons/ssh/impl/j2ssh/J2SSHConnection.java
+++ b/src/src/net/sf/commons/ssh/impl/j2ssh/J2SSHConnection.java
@@ -110,7 +110,7 @@ public class J2SSHConnection extends AbstractConnection
 	@Override
 	public ShellSession createShellSession()
 	{
-		ShellSession session = new J2SSHShellSession(this,connection);
+		ShellSession session = new J2SSHShellSession(this, connection);
 		registerChild(session);
 		return session;
 	}
@@ -118,7 +118,9 @@ public class J2SSHConnection extends AbstractConnection
 	@Override
 	public SubsystemSession createSubsystemSession()
 	{
-		throw new UnsupportedOperationException("createSubsystemSession is not supported");
+		SubsystemSession session = new J2SSHSubsystemSession(this, connection);
+		registerChild(session);
+		return session;
 	}
 
 	/**

--- a/src/src/net/sf/commons/ssh/impl/j2ssh/J2SSHConnector.java
+++ b/src/src/net/sf/commons/ssh/impl/j2ssh/J2SSHConnector.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 @SupportedFeatures(
         {
                 Feature.SSH2, Feature.SYNCHRONOUS, Feature.AUTH_CREDENTIALS, Feature.AUTH_PUBLIC_KEY,
-                Feature.CONNECTION_TIMEOUT, Feature.SOCKET_TIMEOUT, Feature.SESSION_SHELL, Feature.ERROR_STREAM,
+                Feature.CONNECTION_TIMEOUT, Feature.SOCKET_TIMEOUT, Feature.SESSION_SHELL, Feature.SESSION_SUBSYSTEM, Feature.ERROR_STREAM,
                 Feature.AUTHENTICATE_TIMEOUT, Feature.CONNECT_WITHOUT_AUTHENTICATE
         })
 public class J2SSHConnector extends AbstractConnector {

--- a/src/src/net/sf/commons/ssh/impl/j2ssh/J2SSHShellSession.java
+++ b/src/src/net/sf/commons/ssh/impl/j2ssh/J2SSHShellSession.java
@@ -30,7 +30,7 @@ import net.sf.commons.ssh.session.ShellSessionPropertiesBuilder;
  */
 public class J2SSHShellSession extends AbstractSession implements ShellSession
 {
-	private SessionChannelClient session;
+	protected SessionChannelClient session;
 	/**
 	 * @param properties
 	 */

--- a/src/src/net/sf/commons/ssh/impl/j2ssh/J2SSHSubsystemSession.java
+++ b/src/src/net/sf/commons/ssh/impl/j2ssh/J2SSHSubsystemSession.java
@@ -25,8 +25,8 @@ public class J2SSHSubsystemSession extends J2SSHShellSession implements Subsyste
     @Override
     protected void openImpl() throws IOException
     {
-        log.trace("openImpl(): open j2ssh shell session");
         SubsystemSessionPropertiesBuilder sspb = SubsystemSessionPropertiesBuilder.getInstance();
+        if (log.isTraceEnabled()) log.trace("openImpl(): open j2ssh subsystem '" + sspb.getSubsystemName(this) + "' session");
         sspb.verify(this);
         try
         {
@@ -39,7 +39,7 @@ public class J2SSHSubsystemSession extends J2SSHShellSession implements Subsyste
             if(!isSuccess)
                 throw new IOException("Can't open pseudo terminal");
             if(!session.startSubsystem(sspb.getSubsystemName(this)))
-                throw new IOException("Can't start shell");
+                throw new IOException("Can't start subsystem");
         }
         catch (Exception e)
         {

--- a/src/src/net/sf/commons/ssh/impl/j2ssh/J2SSHSubsystemSession.java
+++ b/src/src/net/sf/commons/ssh/impl/j2ssh/J2SSHSubsystemSession.java
@@ -1,6 +1,7 @@
 package net.sf.commons.ssh.impl.j2ssh;
 
 import com.sshtools.j2ssh.SshClient;
+import net.sf.commons.ssh.common.LogUtils;
 import net.sf.commons.ssh.common.UnexpectedRuntimeException;
 import net.sf.commons.ssh.options.Properties;
 import net.sf.commons.ssh.session.SubsystemSession;
@@ -26,7 +27,7 @@ public class J2SSHSubsystemSession extends J2SSHShellSession implements Subsyste
     protected void openImpl() throws IOException
     {
         SubsystemSessionPropertiesBuilder sspb = SubsystemSessionPropertiesBuilder.getInstance();
-        if (log.isTraceEnabled()) log.trace("openImpl(): open j2ssh subsystem '" + sspb.getSubsystemName(this) + "' session");
+        LogUtils.trace(log, "openImpl(): open j2ssh subsystem " + sspb.getSubsystemName(this) + " session");
         sspb.verify(this);
         try
         {

--- a/src/src/net/sf/commons/ssh/impl/j2ssh/J2SSHSubsystemSession.java
+++ b/src/src/net/sf/commons/ssh/impl/j2ssh/J2SSHSubsystemSession.java
@@ -1,0 +1,61 @@
+package net.sf.commons.ssh.impl.j2ssh;
+
+import com.sshtools.j2ssh.SshClient;
+import net.sf.commons.ssh.common.UnexpectedRuntimeException;
+import net.sf.commons.ssh.options.Properties;
+import net.sf.commons.ssh.session.SubsystemSession;
+import net.sf.commons.ssh.session.SubsystemSessionPropertiesBuilder;
+
+import java.io.IOException;
+
+/**
+ * @author veentoo
+ * @date 5/5/2016
+ */
+public class J2SSHSubsystemSession extends J2SSHShellSession implements SubsystemSession {
+    /**
+     * @param properties
+     * @param connection
+     */
+    public J2SSHSubsystemSession(Properties properties, SshClient connection)
+    {
+        super(properties, connection);
+    }
+
+    @Override
+    protected void openImpl() throws IOException
+    {
+        log.trace("openImpl(): open j2ssh shell session");
+        SubsystemSessionPropertiesBuilder sspb = SubsystemSessionPropertiesBuilder.getInstance();
+        sspb.verify(this);
+        try
+        {
+            boolean isSuccess = session.requestPseudoTerminal(sspb.getTerminalType(this),
+                    sspb.getTerminalCols(this),
+                    sspb.getTerminalRows(this),
+                    sspb.getTerminalWidth(this),
+                    sspb.getTerminalHeight(this),
+                    "");
+            if(!isSuccess)
+                throw new IOException("Can't open pseudo terminal");
+            if(!session.startSubsystem(sspb.getSubsystemName(this)))
+                throw new IOException("Can't start shell");
+        }
+        catch (Exception e)
+        {
+            try
+            {
+                session.close();
+            }
+            catch (Exception e1)
+            {
+                log.error("can't close session",e);
+            }
+            if(e instanceof RuntimeException)
+                throw (RuntimeException) e;
+            if(e instanceof IOException)
+                throw (IOException)e;
+            throw new UnexpectedRuntimeException(e.getMessage(),e);
+        }
+    }
+}

--- a/src/src/net/sf/commons/ssh/impl/jsch/JSCHConnection.java
+++ b/src/src/net/sf/commons/ssh/impl/jsch/JSCHConnection.java
@@ -28,6 +28,7 @@ import net.sf.commons.ssh.options.Properties;
 import net.sf.commons.ssh.session.ExecSession;
 import net.sf.commons.ssh.session.SFTPSession;
 import net.sf.commons.ssh.session.ShellSession;
+import net.sf.commons.ssh.session.SubsystemSession;
 
 
 /**
@@ -94,11 +95,28 @@ public class JSCHConnection extends AbstractConnection
 		return session;
 	}
 
+	@Override
+	public SubsystemSession createSubsystemSession()
+	{
+		ChannelSubsystem channel;
+		try
+		{
+			channel = (ChannelSubsystem) connection.openChannel("subsystem");
+		}
+		catch (JSchException e)
+		{
+			throw new UnexpectedRuntimeException(e.getMessage(),e);
+		}
+		JSCHSubsystemSession session = new JSCHSubsystemSession(this, channel);
+		registerChild(session);
+		return session;
+	}
+
 	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see net.sf.commons.ssh.connection.Connection#createExecSession()
-	 */
+         * (non-Javadoc)
+         *
+         * @see net.sf.commons.ssh.connection.Connection#createExecSession()
+         */
 	@Override
 	public ExecSession createExecSession()
 	{

--- a/src/src/net/sf/commons/ssh/impl/jsch/JSCHConnector.java
+++ b/src/src/net/sf/commons/ssh/impl/jsch/JSCHConnector.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 @SupportedFeatures(
         {
                 Feature.SSH2, Feature.SYNCHRONOUS, Feature.AUTH_CREDENTIALS, Feature.AUTH_PUBLIC_KEY,
-                Feature.CONNECTION_TIMEOUT, Feature.SOCKET_TIMEOUT, Feature.SESSION_SHELL, Feature.ERROR_STREAM,
+                Feature.CONNECTION_TIMEOUT, Feature.SOCKET_TIMEOUT, Feature.SESSION_SHELL, Feature.SESSION_SUBSYSTEM, Feature.ERROR_STREAM,
                 Feature.AUTH_NONE, Feature.AUTHENTICATE_TIMEOUT, Feature.AUTHENTICATE_TIMEOUT, Feature.SOCKS4_PROXY,
                 Feature.SOCKS5_PROXY, Feature.HTTP_PROXY
         })

--- a/src/src/net/sf/commons/ssh/impl/jsch/JSCHSession.java
+++ b/src/src/net/sf/commons/ssh/impl/jsch/JSCHSession.java
@@ -1,0 +1,80 @@
+package net.sf.commons.ssh.impl.jsch;
+
+import com.jcraft.jsch.Channel;
+import net.sf.commons.ssh.common.IOUtils;
+import net.sf.commons.ssh.common.PipedOutputStream;
+import net.sf.commons.ssh.common.Status;
+import net.sf.commons.ssh.event.events.ClosedEvent;
+import net.sf.commons.ssh.options.Properties;
+import net.sf.commons.ssh.session.AbstractSession;
+import net.sf.commons.ssh.session.ShellSession;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * @author veentoo
+ * @date 27.04.2016
+ * @since 2.0.5
+ */
+public abstract class JSCHSession extends AbstractSession {
+
+    protected Channel session;
+    protected InputStream in;
+    protected PipedOutputStream libraryOut;
+
+    protected OutputStream out;
+    protected InputStream err;
+    protected PipedOutputStream libraryErr;
+
+    public JSCHSession(Properties properties)
+    {
+        super(properties);
+    }
+
+    /**
+     * @see net.sf.commons.ssh.common.AbstractClosable#closeImpl()
+     */
+    @Override
+    protected void closeImpl() throws IOException
+    {
+        if(libraryOut !=null)
+            libraryOut.setOnWrite(null);
+        if(libraryErr != null)
+            libraryErr.setOnWrite(null);
+        session.disconnect();
+        IOUtils.close(in);
+        in=null;
+        IOUtils.close(out);
+        out = null;
+        IOUtils.close(err);
+        err = null;
+        IOUtils.close(libraryErr);
+        libraryErr = null;
+        IOUtils.close(libraryOut);
+        libraryOut = null;
+        setContainerStatus(Status.CLOSED);
+        fire(new ClosedEvent(this));
+    }
+
+    /**
+     * @see net.sf.commons.ssh.session.Session#isOpened()
+     */
+    @Override
+    public boolean isOpened()
+    {
+        Status status = getContainerStatus();
+        return session.isConnected() && (status == Status.OPENNED || status == Status.INPROGRESS);
+    }
+
+    /**
+     * @see net.sf.commons.ssh.common.Closable#isClosed()
+     */
+    @Override
+    public boolean isClosed()
+    {
+        return session.isClosed();
+    }
+
+}

--- a/src/src/net/sf/commons/ssh/impl/jsch/JSCHSubsystemSession.java
+++ b/src/src/net/sf/commons/ssh/impl/jsch/JSCHSubsystemSession.java
@@ -36,7 +36,7 @@ public class JSCHSubsystemSession extends JSCHSession implements SubsystemSessio
     protected void openImpl() throws IOException
     {
         SubsystemSessionPropertiesBuilder sspb = SubsystemSessionPropertiesBuilder.getInstance();
-        if (log.isTraceEnabled()) log.trace("openImpl(): open jsch subsystem '" + sspb.getSubsystemName(this) + "' session");
+        LogUtils.trace(log, "openImpl(): open jsch subsystem " + sspb.getSubsystemName(this) + " session");
         sspb.verify(this);
         ((ChannelSubsystem)session).setSubsystem(sspb.getSubsystemName(this));
         ((ChannelSubsystem)session).setPty(true);

--- a/src/src/net/sf/commons/ssh/impl/jsch/JSCHSubsystemSession.java
+++ b/src/src/net/sf/commons/ssh/impl/jsch/JSCHSubsystemSession.java
@@ -7,8 +7,8 @@ import net.sf.commons.ssh.event.AbstractEventProcessor;
 import net.sf.commons.ssh.event.events.OpennedEvent;
 import net.sf.commons.ssh.event.events.ReadAvailableEvent;
 import net.sf.commons.ssh.options.Properties;
-import net.sf.commons.ssh.session.ShellSessionPropertiesBuilder;
 import net.sf.commons.ssh.session.SubsystemSession;
+import net.sf.commons.ssh.session.SubsystemSessionPropertiesBuilder;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -36,8 +36,11 @@ public class JSCHSubsystemSession extends JSCHSession implements SubsystemSessio
     protected void openImpl() throws IOException
     {
         log.trace("openImpl(): open jsch subsystem session");
-        ShellSessionPropertiesBuilder sspb = ShellSessionPropertiesBuilder.getInstance();
+        SubsystemSessionPropertiesBuilder sspb = SubsystemSessionPropertiesBuilder.getInstance();
         sspb.verify(this);
+        log.info("getSubsystemName: " + sspb.getSubsystemName(this));
+        ((ChannelSubsystem)session).setSubsystem(sspb.getSubsystemName(this));
+        ((ChannelSubsystem)session).setPty(true);
         ((ChannelSubsystem)session).setPtyType(sspb.getTerminalType(this), sspb.getTerminalCols(this), sspb.getTerminalRows(this),
                 sspb.getTerminalWidth(this), sspb.getTerminalHeight(this));
 

--- a/src/src/net/sf/commons/ssh/impl/jsch/JSCHSubsystemSession.java
+++ b/src/src/net/sf/commons/ssh/impl/jsch/JSCHSubsystemSession.java
@@ -35,10 +35,9 @@ public class JSCHSubsystemSession extends JSCHSession implements SubsystemSessio
     @Override
     protected void openImpl() throws IOException
     {
-        log.trace("openImpl(): open jsch subsystem session");
         SubsystemSessionPropertiesBuilder sspb = SubsystemSessionPropertiesBuilder.getInstance();
+        if (log.isTraceEnabled()) log.trace("openImpl(): open jsch subsystem '" + sspb.getSubsystemName(this) + "' session");
         sspb.verify(this);
-        log.info("getSubsystemName: " + sspb.getSubsystemName(this));
         ((ChannelSubsystem)session).setSubsystem(sspb.getSubsystemName(this));
         ((ChannelSubsystem)session).setPty(true);
         ((ChannelSubsystem)session).setPtyType(sspb.getTerminalType(this), sspb.getTerminalCols(this), sspb.getTerminalRows(this),

--- a/src/src/net/sf/commons/ssh/impl/jsch/JSCHSubsystemSession.java
+++ b/src/src/net/sf/commons/ssh/impl/jsch/JSCHSubsystemSession.java
@@ -1,0 +1,139 @@
+package net.sf.commons.ssh.impl.jsch;
+
+import com.jcraft.jsch.ChannelSubsystem;
+import com.jcraft.jsch.JSchException;
+import net.sf.commons.ssh.common.*;
+import net.sf.commons.ssh.event.AbstractEventProcessor;
+import net.sf.commons.ssh.event.events.OpennedEvent;
+import net.sf.commons.ssh.event.events.ReadAvailableEvent;
+import net.sf.commons.ssh.options.Properties;
+import net.sf.commons.ssh.session.ShellSessionPropertiesBuilder;
+import net.sf.commons.ssh.session.SubsystemSession;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * @author veentoo
+ * @date 27.04.2016
+ * @since 2.0.5
+ */
+public class JSCHSubsystemSession extends JSCHSession implements SubsystemSession {
+
+    /**
+     * @param properties
+     * @param session
+     */
+    public JSCHSubsystemSession(Properties properties, ChannelSubsystem session) {
+        super(properties);
+        this.session = session;
+        setContainerStatus(Status.CREATED);
+    }
+
+
+    @Override
+    protected void openImpl() throws IOException
+    {
+        log.trace("openImpl(): open jsch subsystem session");
+        ShellSessionPropertiesBuilder sspb = ShellSessionPropertiesBuilder.getInstance();
+        sspb.verify(this);
+        ((ChannelSubsystem)session).setPtyType(sspb.getTerminalType(this), sspb.getTerminalCols(this), sspb.getTerminalRows(this),
+                sspb.getTerminalWidth(this), sspb.getTerminalHeight(this));
+
+        final Integer initialSize = PipePropertiesBuilder.getInstance().getInitialSize(this);
+        final Integer maximumSize = PipePropertiesBuilder.getInstance().getMaximumSize(this);
+        final Integer stepSize = PipePropertiesBuilder.getInstance().getStepSize(this);
+        final Integer modifier = PipePropertiesBuilder.getInstance().getModifier(this);
+        final BufferAllocator allocator= PipePropertiesBuilder.getInstance().getAllocator(this);
+
+        PipedInputStream outPipe = new PipedInputStream(initialSize,maximumSize,stepSize,modifier,allocator);
+        out = new PipedOutputStream(outPipe);
+        session.setInputStream(outPipe);
+
+        in = new PipedInputStream(initialSize,maximumSize,stepSize,modifier,allocator);
+        libraryOut = new PipedOutputStream((PipedInputStream) in);
+
+        //fire events
+        final AbstractEventProcessor thisSession = this;
+        libraryOut.setOnWrite(new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                fire(new ReadAvailableEvent(thisSession, in, false));
+            }
+        });
+
+        session.setOutputStream(libraryOut);
+        if (sspb.isSeparateErrorStream(this))
+        {
+            err = new PipedInputStream(initialSize,maximumSize,stepSize,modifier,allocator);
+            libraryErr = new PipedOutputStream((PipedInputStream) err);
+            libraryErr.setOnWrite(new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    fire(new ReadAvailableEvent(thisSession, err, false));
+                }
+            });
+            session.setExtOutputStream(libraryErr);
+        }
+        else
+        {
+            err = in;
+            session.setExtOutputStream(libraryOut);
+        }
+
+        try
+        {
+            Long timeout = sspb.getOpenTimeout(this);
+            if(timeout == null)
+                session.connect();
+            else
+                session.connect(timeout.intValue());
+        }
+        catch (JSchException e)
+        {
+            log.error("session connection failed", e);
+            throw new IOException(e.getMessage(), e);
+        }
+        setContainerStatus(Status.OPENNED);
+        fire(new OpennedEvent(this));
+        setContainerStatus(Status.INPROGRESS);
+    }
+
+    /**
+     * @see net.sf.commons.ssh.session.ShellSession#getInputStream()
+     */
+    @Override
+    public InputStream getInputStream() throws IOException
+    {
+        return in;
+    }
+
+    /**
+     * @see net.sf.commons.ssh.session.ShellSession#getOutputStream()
+     */
+    @Override
+    public OutputStream getOutputStream() throws IOException
+    {
+        return out;
+    }
+
+    /**
+     * @see net.sf.commons.ssh.session.ShellSession#getErrorStream()
+     */
+    @Override
+    public InputStream getErrorStream() throws IOException
+    {
+        return err;
+    }
+
+    @Override
+    public boolean isEOF() throws IOException
+    {
+        return session.isEOF();
+    }
+}

--- a/src/src/net/sf/commons/ssh/impl/sshd/SSHDConnectionSync.java
+++ b/src/src/net/sf/commons/ssh/impl/sshd/SSHDConnectionSync.java
@@ -9,6 +9,7 @@ import java.security.PublicKey;
 
 import net.sf.commons.ssh.session.*;
 import org.apache.sshd.SshClient;
+import org.apache.sshd.client.channel.ChannelSession;
 import org.apache.sshd.client.future.AuthFuture;
 import org.apache.sshd.client.future.ConnectFuture;
 import org.apache.sshd.client.session.ClientSessionImpl;
@@ -92,7 +93,17 @@ public class SSHDConnectionSync extends AbstractConnection
 	@Override
 	public ShellSession createShellSession()
 	{
-		ShellSession session = new SSHDShellSync(this,connection);
+		ChannelSession channel;
+		try
+		{
+			channel = connection.createShellChannel();
+		}
+		catch (Exception e)
+		{
+			log.error("can't create sshd shell session");
+			throw new UnexpectedRuntimeException(e.getMessage(),e);
+		}
+		ShellSession session = new SSHDShellSync(this, channel);
 		registerChild(session);
 		return session;
 	}
@@ -100,7 +111,19 @@ public class SSHDConnectionSync extends AbstractConnection
 	@Override
 	public SubsystemSession createSubsystemSession()
 	{
-		throw new UnsupportedOperationException("createSubsystemSession is not supported");
+		ChannelSession channel;
+		try
+		{
+			channel = connection.createSubsystemChannel(SubsystemSessionPropertiesBuilder.getInstance().getSubsystemName(this));
+		}
+		catch (Exception e)
+		{
+			log.error("can't create sshd shell session");
+			throw new UnexpectedRuntimeException(e.getMessage(),e);
+		}
+		SubsystemSession session = new SSHDSubsystemSync(this, channel);
+		registerChild(session);
+		return session;
 	}
 
 	/**

--- a/src/src/net/sf/commons/ssh/impl/sshd/SSHDConnectionSync.java
+++ b/src/src/net/sf/commons/ssh/impl/sshd/SSHDConnectionSync.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.security.PublicKey;
 
 
+import net.sf.commons.ssh.session.*;
 import org.apache.sshd.SshClient;
 import org.apache.sshd.client.future.AuthFuture;
 import org.apache.sshd.client.future.ConnectFuture;
@@ -26,10 +27,6 @@ import net.sf.commons.ssh.event.events.AuthenticatedEvent;
 import net.sf.commons.ssh.event.events.ClosedEvent;
 import net.sf.commons.ssh.event.events.ConnectedEvent;
 import net.sf.commons.ssh.options.Properties;
-import net.sf.commons.ssh.session.ExecSession;
-import net.sf.commons.ssh.session.SFTPSession;
-import net.sf.commons.ssh.session.Session;
-import net.sf.commons.ssh.session.ShellSession;
 import net.sf.commons.ssh.errors.Error;
 import net.sf.commons.ssh.errors.ErrorLevel;
 
@@ -98,6 +95,12 @@ public class SSHDConnectionSync extends AbstractConnection
 		ShellSession session = new SSHDShellSync(this,connection);
 		registerChild(session);
 		return session;
+	}
+
+	@Override
+	public SubsystemSession createSubsystemSession()
+	{
+		throw new UnsupportedOperationException("createSubsystemSession is not supported");
 	}
 
 	/**

--- a/src/src/net/sf/commons/ssh/impl/sshd/SSHDConnectionSync.java
+++ b/src/src/net/sf/commons/ssh/impl/sshd/SSHDConnectionSync.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.security.PublicKey;
 
 
+import net.sf.commons.ssh.common.LogUtils;
 import net.sf.commons.ssh.session.*;
 import org.apache.sshd.SshClient;
 import org.apache.sshd.client.channel.ChannelSession;
@@ -114,8 +115,7 @@ public class SSHDConnectionSync extends AbstractConnection
 		ChannelSession channel;
 		try
 		{
-			if (log.isTraceEnabled()) log.trace("starting sshd subsystem " +
-					"'" + SubsystemSessionPropertiesBuilder.getInstance().getSubsystemName(this) + "' session");
+			LogUtils.trace(log, "starting sshd subsystem " + SubsystemSessionPropertiesBuilder.getInstance().getSubsystemName(this) + " session");
 			channel = connection.createSubsystemChannel(SubsystemSessionPropertiesBuilder.getInstance().getSubsystemName(this));
 		}
 		catch (Exception e)

--- a/src/src/net/sf/commons/ssh/impl/sshd/SSHDConnectionSync.java
+++ b/src/src/net/sf/commons/ssh/impl/sshd/SSHDConnectionSync.java
@@ -201,16 +201,19 @@ public class SSHDConnectionSync extends AbstractConnection
 	@Override
 	protected void closeImpl() throws IOException
 	{
-		connection.close(false);
-		Long timeout = SSHDPropertiesBuilder.Connection.getInstance().getSyncTimeout(this);
-		int status = connection.waitFor(ClientSessionImpl.CLOSED, timeout);
-		if((status & ClientSessionImpl.CLOSED) == 0)
+		if (connection != null)
 		{
-			connection.close(true);
-			Error error = new Error("Graseful close didn't complete in "+timeout+"ms", this, ErrorLevel.WARN
-					, null, "close()",log);
-			error.writeLog();
-			pushError(error);
+			connection.close(false);
+			Long timeout = SSHDPropertiesBuilder.Connection.getInstance().getSyncTimeout(this);
+			int status = connection.waitFor(ClientSessionImpl.CLOSED, timeout);
+			if ((status & ClientSessionImpl.CLOSED) == 0)
+			{
+				connection.close(true);
+				Error error = new Error("Graseful close didn't complete in " + timeout + "ms", this, ErrorLevel.WARN
+						, null, "close()", log);
+				error.writeLog();
+				pushError(error);
+			}
 		}
 		setContainerStatus(Status.CLOSED);
 		fire(new ClosedEvent(this));

--- a/src/src/net/sf/commons/ssh/impl/sshd/SSHDConnectionSync.java
+++ b/src/src/net/sf/commons/ssh/impl/sshd/SSHDConnectionSync.java
@@ -114,6 +114,8 @@ public class SSHDConnectionSync extends AbstractConnection
 		ChannelSession channel;
 		try
 		{
+			if (log.isTraceEnabled()) log.trace("starting sshd subsystem " +
+					"'" + SubsystemSessionPropertiesBuilder.getInstance().getSubsystemName(this) + "' session");
 			channel = connection.createSubsystemChannel(SubsystemSessionPropertiesBuilder.getInstance().getSubsystemName(this));
 		}
 		catch (Exception e)

--- a/src/src/net/sf/commons/ssh/impl/sshd/SSHDConnector.java
+++ b/src/src/net/sf/commons/ssh/impl/sshd/SSHDConnector.java
@@ -22,7 +22,7 @@ import java.io.IOException;
  * @since 2.0
  */
 @SupportedFeatures({Feature.AUTH_CREDENTIALS, Feature.AUTH_PUBLIC_KEY, Feature.AUTHENTICATE_TIMEOUT, Feature.CONNECT_WITHOUT_AUTHENTICATE,
-        Feature.CONNECTION_TIMEOUT, Feature.ERROR_STREAM, Feature.SESSION_SHELL, Feature.SOCKET_TIMEOUT, Feature.SSH2, Feature.SYNCHRONOUS})
+        Feature.CONNECTION_TIMEOUT, Feature.ERROR_STREAM, Feature.SESSION_SHELL, Feature.SESSION_SUBSYSTEM, Feature.SOCKET_TIMEOUT, Feature.SSH2, Feature.SYNCHRONOUS})
 public class SSHDConnector extends AbstractConnector {
     private SshClient client;
 

--- a/src/src/net/sf/commons/ssh/impl/sshd/SSHDShellSync.java
+++ b/src/src/net/sf/commons/ssh/impl/sshd/SSHDShellSync.java
@@ -12,7 +12,6 @@ import net.sf.commons.ssh.session.AbstractSession;
 import net.sf.commons.ssh.session.ShellSession;
 import net.sf.commons.ssh.session.ShellSessionPropertiesBuilder;
 import org.apache.sshd.ClientChannel;
-import org.apache.sshd.ClientSession;
 import org.apache.sshd.client.channel.ChannelSession;
 import org.apache.sshd.client.future.OpenFuture;
 
@@ -32,18 +31,10 @@ public class SSHDShellSync extends AbstractSession implements ShellSession
     private PipedInputStream stdErr;
     private PipedOutputStream stdIn;
 
-    public SSHDShellSync(Properties properties,ClientSession connection)
+    public SSHDShellSync(Properties properties, ChannelSession channel)
     {
         super(properties);
-        try
-        {
-            channel = connection.createShellChannel();
-        }
-        catch (Exception e)
-        {
-			log.error("can't create sshd shell session");
-			throw new UnexpectedRuntimeException(e.getMessage(),e);
-        }
+        this.channel = channel;
         setContainerStatus(Status.CREATED);
     }
 

--- a/src/src/net/sf/commons/ssh/impl/sshd/SSHDSubsystemSync.java
+++ b/src/src/net/sf/commons/ssh/impl/sshd/SSHDSubsystemSync.java
@@ -1,0 +1,17 @@
+package net.sf.commons.ssh.impl.sshd;
+
+import net.sf.commons.ssh.options.Properties;
+import net.sf.commons.ssh.session.SubsystemSession;
+import org.apache.sshd.client.channel.ChannelSession;
+
+/**
+ * @author veentoo
+ * @date 5/5/2016
+ */
+public class SSHDSubsystemSync extends SSHDShellSync implements SubsystemSession {
+
+    public SSHDSubsystemSync(Properties properties, ChannelSession channel)
+    {
+        super(properties, channel);
+    }
+}

--- a/src/src/net/sf/commons/ssh/impl/ussh/UnixSshConnection.java
+++ b/src/src/net/sf/commons/ssh/impl/ussh/UnixSshConnection.java
@@ -10,6 +10,7 @@ import net.sf.commons.ssh.options.Properties;
 import net.sf.commons.ssh.session.ExecSession;
 import net.sf.commons.ssh.session.SFTPSession;
 import net.sf.commons.ssh.session.ShellSession;
+import net.sf.commons.ssh.session.SubsystemSession;
 import net.sf.commons.ssh.verification.IgnoreVerificationRepository;
 import net.sf.commons.ssh.verification.VerificationEntry;
 import net.sf.commons.ssh.verification.VerificationRepository;
@@ -134,6 +135,12 @@ public class UnixSshConnection extends AbstractConnection {
     @Override
     public ShellSession createShellSession() {
         return new UnixSshShellSession(this, sshProcess);
+    }
+
+    @Override
+    public SubsystemSession createSubsystemSession()
+    {
+        throw new UnsupportedOperationException("createSubsystemSession is not supported");
     }
 
     @Override

--- a/src/src/net/sf/commons/ssh/impl/ussh/UnixSshConnection.java
+++ b/src/src/net/sf/commons/ssh/impl/ussh/UnixSshConnection.java
@@ -84,8 +84,7 @@ public class UnixSshConnection extends AbstractConnection {
                 command = StringUtils.replace(command, "#$HOST_CHECK$#", "yes");
                 command = StringUtils.replace(command, "#$REPOSITORY$#", "-o UserKnownHostsFile=" + StringUtils.replace(known_host.getAbsolutePath(), " ", "\\ "));
             }
-            if (log.isTraceEnabled())
-                log.trace("connect string: " + command);
+            LogUtils.trace(log, "connect string: " + command);
         }
         try {
             sshProcess = Runtime.getRuntime().exec(command);

--- a/src/src/net/sf/commons/ssh/session/ShellSessionPropertiesBuilder.java
+++ b/src/src/net/sf/commons/ssh/session/ShellSessionPropertiesBuilder.java
@@ -19,6 +19,8 @@ public class ShellSessionPropertiesBuilder extends SessionPropertiesBuilder
     public static final String KEY_TERMINAL_WIDTH="net.sf.commons.ssh.options.ShellSessionOptionsBuilder.terminalWidth";
     @PropertyType(value = Boolean.class,required = true)
     public static final String KEY_SEPARATE_ERROR_STREAM = "net.sf.commons.ssh.options.ShellSessionOptionsBuilder.errorStream";
+//    @PropertyType(value = String.class,required = false)
+//    public static final String KEY_START_SUBSYSTEM = "net.sf.commons.ssh.options.ShellSessionOptionsBuilder.subSystem";
 
     public synchronized static ShellSessionPropertiesBuilder getInstance()
     {

--- a/src/src/net/sf/commons/ssh/session/SubsystemSession.java
+++ b/src/src/net/sf/commons/ssh/session/SubsystemSession.java
@@ -1,0 +1,9 @@
+package net.sf.commons.ssh.session;
+
+/**
+ * @author veentoo
+ * @date 27.04.2016
+ * @since 2.0.5
+ */
+public interface SubsystemSession extends ShellSession {
+}

--- a/src/src/net/sf/commons/ssh/session/SubsystemSessionPropertiesBuilder.java
+++ b/src/src/net/sf/commons/ssh/session/SubsystemSessionPropertiesBuilder.java
@@ -1,0 +1,40 @@
+package net.sf.commons.ssh.session;
+
+import net.sf.commons.ssh.options.Configurable;
+import net.sf.commons.ssh.options.Properties;
+import net.sf.commons.ssh.options.PropertyType;
+
+
+/**
+ * @author veentoo
+ * @date 4/28/2016
+ */
+public class SubsystemSessionPropertiesBuilder extends ShellSessionPropertiesBuilder {
+
+    private static volatile SubsystemSessionPropertiesBuilder instance = null;
+
+    @PropertyType(value = String.class, required = true)
+    public static final String KEY_SUBSYSTEM_NAME ="net.sf.commons.ssh.options.SubsystemSessionPropertiesBuilder.subsystemName";
+
+    public static SubsystemSessionPropertiesBuilder getInstance()
+    {
+        if (instance == null)
+        {
+            synchronized (SubsystemSessionPropertiesBuilder.class) {
+                if (instance == null) {
+                    instance = new SubsystemSessionPropertiesBuilder();
+                }
+            }
+        }
+        return instance;
+    }
+
+    public String getSubsystemName(Properties opt) {
+        return (String) getProperty(opt, KEY_SUBSYSTEM_NAME);
+    }
+
+    public void setSubsystemName(Configurable options, String subsystemName) {
+        options.setProperty(KEY_SUBSYSTEM_NAME, subsystemName);
+    }
+
+}


### PR DESCRIPTION
Please review and merge changes that allow creation of subsystem sessions
like `ssh -l login -s host netconf` where **netconf** is subsystem name

Added new feature SESSION_SUBSYSTEM, SubsystemSessionPropertiesBuilder and implementation classes for all 4 supported crypto libraries.

Please respond as soon as possible.
